### PR TITLE
Remove unnecessary check in ParseTwitterHandle

### DIFF
--- a/twitter.go
+++ b/twitter.go
@@ -21,9 +21,6 @@ func ParseTwitterHandle(twitterURL string) (TwitterHandle, error) {
 	if err != nil {
 		return TwitterHandle(""), ErrInvalidTwitterHandle
 	}
-	if t == "" {
-		return TwitterHandle(""), ErrInvalidTwitterHandle
-	}
 
 	if !twitterHandlePattern.MatchString(t) {
 		return TwitterHandle(""), ErrInvalidTwitterHandle


### PR DESCRIPTION
We don't need to check for empty string because the regex enforces that condition