### PR TITLE
Only run in verbose mode when running full unit tests

### DIFF
--- a/dev-scripts/run-unit-tests
+++ b/dev-scripts/run-unit-tests
@@ -1,17 +1,27 @@
 #!/bin/bash
 
+# Runs all unit tests and performs static code analysis.
+#
+# Options:
+#
+#  --full   Include slower, more exhaustive tests and capture test coverage
+#           results (outputs to .coverage.html).
+
 # Exit build script on first failure.
 set -e
 
 # Echo commands to stdout.
 set -x
 
-if [ "$1" = "--full" ]; then
+full_test=""
+go_test_flags=()
+readonly COVERAGE_FILE_RAW=".coverage.out"
+readonly COVERAGE_FILE_HTML=".coverage.html"
+if [[ "$1" = "--full" ]]; then
   full_test="1"
-  flags="-race --coverprofile=.coverage.out"
-else
-  full_test=""
-  flags=""
+  go_test_flags+=("-v")
+  go_test_flags+=("-race")
+  go_test_flags+=("--coverprofile=${COVERAGE_FILE_RAW}")
 fi
 
 # Exit on unset variable.
@@ -28,7 +38,7 @@ if [ ! -f "${STATICCHECK_PATH}" ]; then
     go install "honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION}"
 fi
 
-go test -v $flags ./...
+go test "${go_test_flags[@]}" ./...
 go vet ./...
 $STATICCHECK_PATH ./...
 


### PR DESCRIPTION
Refactor run-unit-tests to only add the verbose flag when we're running the full suite of tests.